### PR TITLE
fix: マージで壊れたpnpm-lock.yamlを修復しデプロイ失敗を解消

### DIFF
--- a/application/pnpm-lock.yaml
+++ b/application/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
         version: 9.5.0
       gifler:
         specifier: github:themadcreator/gifler#v0.3.0
-        version: https://codeload.github.com/themadcreator/gifler/tar.gz/c3259b071c7782f85d4928a5f03d0b378ed003b5
+        version: https://codeload.github.com/themadcreator/gifler/tar.gz/89484cb3db174c584a3138e89664f0167a7760c1
       jquery:
         specifier: 3.7.1
         version: 3.7.1


### PR DESCRIPTION
背景
PR #95 の最後のコミット 9dbeaa6（CyberAgentHack:main のマージ）で、pnpm-lock.yaml 内の gifler パッケージの依存解決エントリが壊れました。
これにより Dockerfile 内の pnpm install --frozen-lockfile が以下のエラーで失敗し、<Fly.io> へのデプロイができない状態になっていました：

ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for
'gifler@<https://codeload.github.com/themadcreator/gifler/tar.gz/c3259b071c7782f85d4928a5f03d0b378ed003b5'>
in pnpm-lock.yaml

達成したいこと
	∙	pnpm install --frozen-lockfile が正常に完了すること
	∙	<Fly.io> へのデプロイ（Docker ビルド）が成功すること

なぜこの方法をとったか
pnpm install --no-frozen-lockfile でlockfileを再生成する方法を採用。pnpmが依存関係を再解決し、正しいコミットハッシュを自動的に設定するため、手動編集よりも安全で確実です。
検討したが採用しなかった方法
	∙	lockfileの手動編集: コミットハッシュを直接書き換える方法。pnpmの内部形式に依存するため、他の箇所にも不整合がある場合に見落とすリスクがあり不採用。